### PR TITLE
Upgrade to work with grunt 4, fixes #4

### DIFF
--- a/gruntFile.js
+++ b/gruntFile.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function(grunt) {
 
 	grunt.initConfig({
@@ -13,14 +15,16 @@ module.exports = function(grunt) {
 				'dest': 'examples/example.min.css'
 			}
 		},
-		'lint': {
-			'files': ['grunt.js', 'tasks/yui-compressor.js']
-		},
 		'watch': {
-			'files': '<config:lint.files>',
+			'files': '<%= jshint.dev.files.src %>',
 			'tasks': 'default'
 		},
 		'jshint': {
+			'dev': {
+				files: {
+					src: ['gruntFile.js', 'tasks/*.js', 'tasks/lib/*.js']
+				}
+			},
 			'options': {
 				'curly': true,
 				'immed': true,
@@ -34,13 +38,14 @@ module.exports = function(grunt) {
 				'es5': true,
 				'trailing': true,
 				'smarttabs': true
-			},
-			'globals': {}
+			}
 		}
 	});
 
+	grunt.loadNpmTasks("grunt-contrib-jshint");
+	grunt.loadNpmTasks("grunt-contrib-watch");
+
 	grunt.loadTasks('tasks');
 
-	grunt.registerTask('default', 'lint min cssmin');
-
+	grunt.registerTask('default', ['jshint:dev', 'min', 'cssmin']);
 };

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
 	"name": "grunt-yui-compressor",
 	"description": "A grunt plugin for compressing JavaScript and CSS files using YUI Compressor.",
@@ -34,11 +35,13 @@
 		"test": "grunt test"
 	},
 	"dependencies": {
-		"grunt": "~0.3.8",
+		"grunt": "~0.4.0",
+		"grunt-lib-contrib": "~0.5.2",
 		"node-minify": "~0.3.10"
 	},
 	"devDependencies": {
-		"grunt": "~0.3.8"
+		"grunt-contrib-jshint": "~0.1.1",
+		"grunt-contrib-watch": "~0.1.4"
 	},
 	"keywords": [
 		"gruntplugin"

--- a/tasks/lib/yui-compressor.js
+++ b/tasks/lib/yui-compressor.js
@@ -1,0 +1,45 @@
+"use strict";
+
+var Compressor = require('node-minify').minify;
+
+exports.init = function(grunt) {
+
+	// Refactored our the min_max_info and concat helpers here
+	// because grunt.helper is removed in future grunt versions
+	var minMax = require("grunt-lib-contrib").init(grunt).minMaxInfo,
+		concat = function(source) {
+			// Kinda hacky, but that's how I roll...
+			return source.map(function (filepath) {
+				return grunt.file.read(filepath);
+			}).join('\n');
+		};
+
+	return function(options) {
+		var source = grunt.file.expand(options.source),
+		    destination = options.destination,
+		    max = concat(source),
+		    min;
+
+		// Ugly hack to create the destination path automatically if needed
+		grunt.file.write(destination, '');
+		
+		// Minify all the things!
+		new Compressor({
+			'type': 'yui-' + options.type,
+			'fileIn': source,
+			'fileOut': destination,
+			'callback': function(error) {
+				if (error) {
+					grunt.warn(error);
+					return options.fn();
+				}
+				min = grunt.file.read(destination);
+				grunt.log.writeln('File `' + destination + '` created.');
+				minMax(min, max);
+				// Let grunt know the asynchronous task has completed
+				options.fn();
+			}
+		});
+	};
+};
+

--- a/tasks/yui-compressor.js
+++ b/tasks/yui-compressor.js
@@ -1,35 +1,11 @@
+"use strict";
+
 module.exports = function(grunt) {
 
-	var Compressor = require('node-minify').minify;
-
-	grunt.registerHelper('yui-compressor', function(options) {
-		var source = grunt.file.expandFiles(options.source),
-		    destination = options.destination,
-		    max = grunt.helper('concat', source),
-		    min;
-		// Ugly hack to create the destination path automatically if needed
-		grunt.file.write(destination, '');
-		// Minify all the things!
-		new Compressor({
-			'type': 'yui-' + options.type,
-			'fileIn': source,
-			'fileOut': destination,
-			'callback': function(error) {
-				if (error) {
-					grunt.warn(error);
-					return options.fn();
-				}
-				min = grunt.file.read(destination);
-				grunt.log.writeln('File `' + destination + '` created.');
-				grunt.helper('min_max_info', min, max);
-				// Let grunt know the asynchronous task has completed
-				options.fn();
-			}
-		});
-	});
+	var yuiCompressor = require("./lib/yui-compressor.js").init(grunt);
 
 	grunt.registerMultiTask('min', 'Minify JavaScript files with YUI Compressor.', function() {
-		grunt.helper('yui-compressor', {
+		yuiCompressor({
 			'type': 'js',
 			'source': this.file.src,
 			'destination': this.file.dest,
@@ -38,7 +14,7 @@ module.exports = function(grunt) {
 	});
 
 	grunt.registerMultiTask('cssmin', 'Minify CSS files with YUI Compressor.', function() {
-		grunt.helper('yui-compressor', {
+		yuiCompressor({
 			'type': 'css',
 			'source': this.file.src,
 			'destination': this.file.dest,


### PR DESCRIPTION
This should be a good start to making this work with grunt 4.  I've spent some time testing it out and making sure the linting and watch tasks still work.

I had a problem with the grunt-contrib-jshint task failing because of a recent syntax change from `this.file.src` to `this.filesSrc` (I have a PR in to [fall back gracefully](https://github.com/gruntjs/grunt-contrib-jshint/pull/15), but they recommend making sure the dependency is at least `0.4.0rc7` instead).  I've updated the reference in the package.json, but in case you see an error related to 'cannot call method forEach` that is probably the culprit.

I added the `"use strict";` on the lint targets because it was complaining and I wasn't sure if you wanted me to disable that in the jshint options.

I'd also probably consider this at least a minor npm version bump so people running grunt 3 aren't caught off guard, but I'm definitely not trying to tell you how to handle your biz.
