### PR TITLE
Add new option to disable 'gzip' report generation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,8 +9,13 @@ module.exports = function(grunt) {
 		},
 		'cssmin': {
 			'dist': {
-				'src': 'examples/example.css',
-				'dest': 'examples/example.min.css'
+				'options': {
+					'report': false
+				},
+				'files': [{
+					'src': 'examples/example.css',
+					'dest': 'examples/example.min.css'
+				}]
 			}
 		},
 		'lint': {

--- a/tasks/lib/yui-compressor.js
+++ b/tasks/lib/yui-compressor.js
@@ -14,9 +14,10 @@ exports.init = function(grunt) {
 
 	return function(options) {
 		var source = grunt.file.expand(options.source),
-		    destination = options.destination,
-		    max = concat(source),
-		    min;
+			destination = options.destination,
+			max = concat(source),
+			min,
+			report = options.report;
 
 		// Ugly hack to create the destination path automatically if needed
 		grunt.file.write(destination, '');
@@ -33,7 +34,7 @@ exports.init = function(grunt) {
 				}
 				min = grunt.file.read(destination);
 				grunt.log.writeln('File `' + destination + '` created.');
-				minMax(min, max, 'gzip');
+				minMax(min, max, report);
 				// Let Grunt know the asynchronous task has completed
 				options.fn();
 			}

--- a/tasks/yui-compressor.js
+++ b/tasks/yui-compressor.js
@@ -7,6 +7,9 @@ module.exports = function(grunt) {
 		var files = this.files;
 		var length = files.length;
 		var count = 0;
+	var options = this.options({
+		report: 'gzip'
+	});
 		files.forEach(function(file) {
 			yuiCompressor({
 				'type': 'js',
@@ -16,7 +19,8 @@ module.exports = function(grunt) {
 					if (++count == length) {
 						done();
 					}
-				}
+				},
+				'report' : options.report
 			});
 		});
 	});
@@ -26,6 +30,9 @@ module.exports = function(grunt) {
 		var files = this.files;
 		var length = files.length;
 		var count = 0;
+	var options = this.options({
+		report: 'gzip'
+	});
 		files.forEach(function(file) {
 			yuiCompressor({
 				'type': 'css',
@@ -35,7 +42,8 @@ module.exports = function(grunt) {
 					if (++count == length) {
 						done();
 					}
-				}
+				},
+				'report' : options.report
 			});
 		});
 	});


### PR DESCRIPTION
Using grunt-lib-contrib to report the minified/gzipped size of the compressed files is useful, but I'd like to be able to disable it for performance reasons (it can slow the task by 10x, as noted in [the lib](https://npmjs.org/package/grunt-lib-contrib))

The API is identical to [grunt-contrib-cssmin's report option](https://github.com/gruntjs/grunt-contrib-cssmin#report), and I've updated the `cssmin` task to show how it can be used.
