### PR TITLE
Fix issue when source and destination has the same path

### DIFF
--- a/tasks/lib/yui-compressor.js
+++ b/tasks/lib/yui-compressor.js
@@ -19,8 +19,11 @@ exports.init = function(grunt) {
 			min,
 			report = options.report;
 
-		// Ugly hack to create the destination path automatically if needed
-		grunt.file.write(destination, '');
+		
+		if (source.indexOf(destination) === -1) {
+			// Ugly hack to create the destination path automatically if needed
+		   grunt.file.write(destination, '');
+		}
 
 		// Minify all the things!
 		new Compressor({


### PR DESCRIPTION
It should override the source rather than creating an empty file.
