### PR TITLE
Allow user to not specify a destination in Gruntfile

### DIFF
--- a/tasks/lib/yui-compressor.js
+++ b/tasks/lib/yui-compressor.js
@@ -19,6 +19,12 @@ exports.init = function(grunt) {
 		var min;
 		var report = options.report;
 
+		// Ugly hack to create the destination path automatically if needed
+		if(destination !== source) {
+			if(!grunt.file.exists(destination))
+				grunt.file.write(destination, '');
+		}
+
 		// Minify all the things!
 		new Compressor({
 			'type': 'yui-' + options.type,


### PR DESCRIPTION
My changes allow the user to not specify a destination or specify the same destination as the source and it will produce the expected output. This allowed me to chain the cssmin task after other tasks that affect the same CSS file (grunt-contrib-less and grunt-combine-media-queries).
![no_destination](https://f.cloud.github.com/assets/4976096/895733/884e4686-fad2-11e2-89cd-af8bb9d7cbed.png)
