### PR TITLE
Fix the Node 0.12 Fatal error

### DIFF
--- a/tasks/yui-compressor.js
+++ b/tasks/yui-compressor.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
 		var length = files.length;
 		var count = 0;
 		var options = this.options({
-			'report': 'gzip'
+			'report': 'min'
 		});
 		files.forEach(function(file) {
 			yuiCompressor({


### PR DESCRIPTION
Change to set the report option to `min` instead of `gzip` to fix a fatal error in NodeJS 0.12.
